### PR TITLE
Backend API Endpoints

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
   "license": "ISC",
   "devDependencies": {
     "@eslint/js": "^9.19.0",
+    "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/node": "^22.13.0",
     "@types/node-cron": "^3.0.11",
@@ -39,8 +40,11 @@
     "typescript-eslint": "^8.22.0"
   },
   "dependencies": {
+    "@types/http-errors": "^2.0.4",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "http-errors": "^2.0.0",
     "module-alias": "^2.2.3",
     "node-cron": "^3.0.3",
     "pg": "^8.13.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -44,6 +44,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "express-async-handler": "^1.2.0",
+    "express-validator": "^7.2.1",
     "http-errors": "^2.0.0",
     "module-alias": "^2.2.3",
     "node-cron": "^3.0.3",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -19,6 +19,12 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.21.2
+      express-async-handler:
+        specifier: ^1.2.0
+        version: 1.2.0
+      express-validator:
+        specifier: ^7.2.1
+        version: 7.2.1
       http-errors:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1452,6 +1458,19 @@ packages:
         integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==,
       }
     engines: { node: ">= 0.6" }
+
+  express-async-handler@1.2.0:
+    resolution:
+      {
+        integrity: sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w==,
+      }
+
+  express-validator@7.2.1:
+    resolution:
+      {
+        integrity: sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==,
+      }
+    engines: { node: ">= 8.0.0" }
 
   express@4.21.2:
     resolution:
@@ -4615,6 +4634,13 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  express-async-handler@1.2.0: {}
+
+  express-validator@7.2.1:
+    dependencies:
+      lodash: 4.17.21
+      validator: 13.12.0
 
   express@4.21.2:
     dependencies:

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -7,12 +7,21 @@ settings:
 importers:
   .:
     dependencies:
+      "@types/http-errors":
+        specifier: ^2.0.4
+        version: 2.0.4
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
       express:
         specifier: ^4.21.2
         version: 4.21.2
+      http-errors:
+        specifier: ^2.0.0
+        version: 2.0.0
       module-alias:
         specifier: ^2.2.3
         version: 2.2.3
@@ -44,6 +53,9 @@ importers:
       "@eslint/js":
         specifier: ^9.19.0
         version: 9.19.0
+      "@types/cors":
+        specifier: ^2.8.17
+        version: 2.8.17
       "@types/express":
         specifier: ^5.0.0
         version: 5.0.0
@@ -291,6 +303,12 @@ packages:
     resolution:
       {
         integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==,
+      }
+
+  "@types/cors@2.8.17":
+    resolution:
+      {
+        integrity: sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==,
       }
 
   "@types/debug@4.1.12":
@@ -949,6 +967,13 @@ packages:
         integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==,
       }
     engines: { node: ">= 0.6" }
+
+  cors@2.8.5:
+    resolution:
+      {
+        integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==,
+      }
+    engines: { node: ">= 0.10" }
 
   cosmiconfig@9.0.0:
     resolution:
@@ -2369,6 +2394,13 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  object-assign@4.1.1:
+    resolution:
+      {
+        integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
+      }
+    engines: { node: ">=0.10.0" }
+
   object-hash@3.0.0:
     resolution:
       {
@@ -3733,6 +3765,10 @@ snapshots:
     dependencies:
       "@types/node": 22.13.0
 
+  "@types/cors@2.8.17":
+    dependencies:
+      "@types/node": 22.13.0
+
   "@types/debug@4.1.12":
     dependencies:
       "@types/ms": 2.1.0
@@ -4208,6 +4244,11 @@ snapshots:
   cookie-signature@1.0.6: {}
 
   cookie@0.7.1: {}
+
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig@9.0.0(typescript@5.7.3):
     dependencies:
@@ -5135,6 +5176,8 @@ snapshots:
       undefsafe: 2.0.5
 
   normalize-path@3.0.0: {}
+
+  object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3,6 +3,7 @@ import cors from "cors";
 import { logger } from "./middleware/logger";
 import env from "./util/validateEnv";
 import errorHandler from "./middleware/errorHandler";
+import courseRouter from "./routes/course.routes";
 
 const app = express();
 
@@ -16,6 +17,9 @@ app.use(
     origin: env.FRONTEND_ORIGIN,
   }),
 );
+
+// Routes
+app.use("/api/course", courseRouter);
 
 /**
  * Error handler; all errors thrown by server are handled here.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,26 @@
+import express from "express";
+import cors from "cors";
+import { logger } from "./middleware/logger";
+import env from "./util/validateEnv";
+import errorHandler from "./middleware/errorHandler";
+
+const app = express();
+
+app.use(express.json());
+
+// logger middleware to log requests
+app.use(logger);
+
+app.use(
+  cors({
+    origin: env.FRONTEND_ORIGIN,
+  }),
+);
+
+/**
+ * Error handler; all errors thrown by server are handled here.
+ * Explicit typings required here because TypeScript cannot infer the argument types.
+ */
+app.use(errorHandler);
+
+export default app;

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,38 @@
+import { NextFunction, Request, Response } from "express";
+import { isHttpError } from "http-errors";
+import { logEvents } from "@/middleware/logger";
+
+const errorHandler = (
+  error: unknown,
+  req: Request,
+  res: Response,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  next: NextFunction,
+) => {
+  // 500 is the "internal server error" error code, this will be our fallback
+  let statusCode = 500;
+  let errorMessage = "An error has occurred.";
+
+  // check is necessary because anything can be thrown, type is not guaranteed
+  if (isHttpError(error)) {
+    // error.status is unique to the http error class, it allows us to pass status codes with errors
+    statusCode = error.status;
+    errorMessage = error.message;
+    logEvents(
+      `${error.name}: ${error.message}\t${req.method}\t${req.url}\t${req.headers.origin}`,
+      "errLog.log",
+    );
+  }
+  // prefer custom http errors but if they don't exist, fallback to default
+  else if (error instanceof Error) {
+    errorMessage = error.message;
+    logEvents(
+      `${error.name}: ${error.message}\t${req.method}\t${req.url}\t${req.headers.origin}`,
+      "errLog.log",
+    );
+  }
+
+  res.status(statusCode).json({ error: errorMessage });
+};
+
+export default errorHandler;

--- a/backend/src/middleware/logger.ts
+++ b/backend/src/middleware/logger.ts
@@ -1,0 +1,30 @@
+import { RequestHandler } from "express";
+import fs from "fs";
+import path from "path";
+
+const fsPromises = fs.promises;
+
+export const logEvents = async (message: string, logFileName: string) => {
+  const dateTime = new Date();
+  const logItem = `${dateTime}\t${message}\n`;
+
+  try {
+    // Create logs directory if it doesn't exist
+    if (!fs.existsSync(path.join(__dirname, "..", "logs"))) {
+      await fsPromises.mkdir(path.join(__dirname, "..", "logs"));
+    }
+
+    await fsPromises.appendFile(
+      path.join(__dirname, "..", "logs", logFileName),
+      logItem,
+    );
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+export const logger: RequestHandler = (req, res, next) => {
+  logEvents(`${req.method}\t${req.url}\t${req.headers.origin}`, "reqLog.log");
+  console.log(`${req.method} ${req.path}`);
+  next();
+};

--- a/backend/src/middleware/logger.ts
+++ b/backend/src/middleware/logger.ts
@@ -5,6 +5,8 @@ import path from "path";
 const fsPromises = fs.promises;
 
 export const logEvents = async (message: string, logFileName: string) => {
+  console.log(message);
+
   const dateTime = new Date();
   const logItem = `${dateTime}\t${message}\n`;
 
@@ -25,6 +27,5 @@ export const logEvents = async (message: string, logFileName: string) => {
 
 export const logger: RequestHandler = (req, res, next) => {
   logEvents(`${req.method}\t${req.url}\t${req.headers.origin}`, "reqLog.log");
-  console.log(`${req.method} ${req.path}`);
   next();
 };

--- a/backend/src/models/Course.model.ts
+++ b/backend/src/models/Course.model.ts
@@ -13,6 +13,8 @@ import {
   UpdatedAt,
 } from "sequelize-typescript";
 import MainSection from "./MainSection.model";
+import SubSection from "./SubSection.model";
+import Exam from "./Exam.model";
 
 // All attributes
 type CourseAttributes = {
@@ -32,10 +34,18 @@ type CourseCreationAttributes = Optional<CourseAttributes, "id">;
  *
  */
 @Scopes(() => ({
-  default: {
+  details: {
     include: [
       {
         model: MainSection,
+        include: [
+          {
+            model: SubSection,
+          },
+          {
+            model: Exam,
+          },
+        ],
       },
     ],
   },

--- a/backend/src/models/MainSection.model.ts
+++ b/backend/src/models/MainSection.model.ts
@@ -17,6 +17,7 @@ import {
 } from "sequelize-typescript";
 import Course from "./Course.model";
 import SubSection from "./SubSection.model";
+import Exam from "./Exam.model";
 
 // All attributes
 type MainSectionAttributes = {
@@ -110,6 +111,9 @@ class MainSection extends Model<
 
   @HasMany(() => SubSection)
   subSections: SubSection[];
+
+  @HasMany(() => Exam)
+  exams: Exam[];
 }
 
 export default MainSection;

--- a/backend/src/routes/course.routes.ts
+++ b/backend/src/routes/course.routes.ts
@@ -1,0 +1,84 @@
+import Course from "@/models/Course.model";
+import validationErrorParser from "@/util/validationErrorParser";
+import { getCourseDetailsValidator } from "@/validators/course.validator";
+import { NextFunction, Request, Response, Router } from "express";
+import asyncHandler from "express-async-handler";
+import { matchedData, validationResult } from "express-validator";
+import createHttpError from "http-errors";
+
+const courseRouter = Router();
+
+type CourseQuery = {
+  // comma-separate list of courses
+  courses: string;
+};
+
+/**
+ * GET /api/courses
+ *
+ * Return all courses with no details
+ */
+courseRouter.get(
+  "/",
+  asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // Get all courses
+      const courses = await Course.findAll();
+
+      res.status(200).json(courses);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }),
+);
+
+/**
+ * GET /api/courses/details?courses="COURSE 1,COURSE 2,COURSE 3..."
+ *
+ * Get details for a list of courses
+ */
+courseRouter.get(
+  "/details",
+  getCourseDetailsValidator,
+  asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
+    const results = validationResult(req);
+
+    if (!results.isEmpty()) {
+      next(createHttpError(400, validationErrorParser(results)));
+      return;
+    }
+
+    const { courses } = matchedData(req, {
+      locations: ["query"],
+    }) as CourseQuery;
+
+    try {
+      const coursesList = courses.split(",").map((course) => course.trim());
+
+      const resCourses = [];
+      for (const course of coursesList) {
+        const foundCourse = await Course.scope("details").findOne({
+          where: {
+            subject: course.split(" ")[0],
+            code: course.split(" ")[1],
+          },
+        });
+
+        if (!foundCourse) {
+          res.status(404).json({
+            message: `${course} not found`,
+          });
+          return;
+        }
+
+        resCourses.push(foundCourse);
+      }
+
+      res.status(200).json(resCourses);
+    } catch (error: unknown) {
+      next(error);
+    }
+  }),
+);
+
+export default courseRouter;

--- a/backend/src/util/logger.ts
+++ b/backend/src/util/logger.ts
@@ -14,7 +14,7 @@ const logger = createLogger({
   transports: [
     new transports.Console({ level: "debug" }), // Console logs everything from debug and above
     new transports.DailyRotateFile({
-      filename: "logs/scraper-%DATE%.log",
+      filename: "logs/server-%DATE%.log",
       datePattern: "YYYY-MM-DD",
       maxSize: "10m",
       maxFiles: "14d",

--- a/backend/src/util/validateEnv.ts
+++ b/backend/src/util/validateEnv.ts
@@ -1,6 +1,10 @@
 import z from "zod";
 
 const envSchema = z.object({
+  PORT: z.string().optional().default("3000"),
+  FRONTEND_ORIGIN: z.string({
+    message: "Missing FRONTEND_ORIGIN in environment variables",
+  }),
   POSTGRES_HOST: z.string({
     message: "Missing POSTGRES_HOST in environment variables",
   }),
@@ -18,4 +22,6 @@ const envSchema = z.object({
   }),
 });
 
-export default envSchema.parse(process.env);
+const env = envSchema.parse(process.env);
+
+export default env;

--- a/backend/src/util/validationErrorParser.ts
+++ b/backend/src/util/validationErrorParser.ts
@@ -1,0 +1,21 @@
+import { Result, ValidationError } from "express-validator";
+
+/**
+ * Parses through errors thrown by validator (if any exist). Error messages are
+ * added to a string and that string is used as the error message for the HTTP
+ * error.
+ *
+ * @param errors the validation result provided by express validator middleware
+ */
+const validationErrorParser = (errors: Result<ValidationError>): string => {
+  let errorString = "";
+  if (!errors.isEmpty()) {
+    // parse through errors returned by the validator and append them to the error string
+    for (const error of errors.array()) {
+      errorString += error.msg + " ";
+    }
+  }
+  return errorString;
+};
+
+export default validationErrorParser;

--- a/backend/src/validators/course.validator.ts
+++ b/backend/src/validators/course.validator.ts
@@ -1,0 +1,8 @@
+import { query } from "express-validator";
+
+const validateParamCourses = query("courses")
+  .isString()
+  .withMessage("Courses must be a comma separated string of courses")
+  .toUpperCase();
+
+export const getCourseDetailsValidator = [validateParamCourses];


### PR DESCRIPTION
## New endpoints:
- GET `/api/course`
    - No params
    - Returns list of all courses, only containing the course subject and code 
    - Intended to be used to generate the course dropdown list
- GET `/api/course/details?courses=[courses]`
    - Returns course full detail for the list of courses specified in the `courses` param
    - `courses` param should be a string of comma separate course full names, e.g. `"CSE 100,CSE101,MATH183"`

## Steps to test:
- First configure a local PostgreSQL instance and put the following fields in the backend `.env` file
    - `PORT`
    - `FRONTEND_ORIGIN`
    - `POSTGRES_HOST`
    - `POSTGRES_PORT`
    - `POSTGRES_USER`
    - `POSTGRES_PASSWORD`
    - `POSTGRES_DB`
- Run `npm run dev` to make sure database connection is successful
- In `index.ts`, uncomment the call to `updateSchedules()` on line 131 
- Start the server, it will now scrape schedule of classes and populate your local database
- THIS SHOULD ONLY BE DONE ONCE
- Comment out line 131 again