### PR TITLE
Limit number of quarters scraped

### DIFF
--- a/backend/src/cron.ts
+++ b/backend/src/cron.ts
@@ -17,6 +17,7 @@ const main = async () => {
           resolve(); // If successful, resolve the promise
         } catch (error) {
           console.error("Error in job execution:", error);
+          console.log(`Retrying in ${RETRY_DELAY / 6000} minutes`);
 
           // Instead of exiting, set a timeout to retry
           setTimeout(runWithRetryHandling, RETRY_DELAY);


### PR DESCRIPTION
## Changes

What changes did you make? Include screenshots if applicable, or explain how to view the changes.

- title^^, because too slow to scrape the entire list of available quarters on schedule of classes

## Testing

How did you confirm your changes work? (Automated tests, manual verification, etc.)

- Manual testing

## Tracking

Add your issue number below.

Resolves #42 
